### PR TITLE
feat: public landing page and authenticated staff dashboard

### DIFF
--- a/src/app/(frontend)/dashboard/logout-button.tsx
+++ b/src/app/(frontend)/dashboard/logout-button.tsx
@@ -1,0 +1,26 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import React, { useState } from 'react'
+
+export default function LogoutButton() {
+  const router = useRouter()
+  const [loading, setLoading] = useState(false)
+
+  const handleLogout = async () => {
+    setLoading(true)
+    await fetch('/api/users/logout', { method: 'POST' }).catch(() => null)
+    router.push('/login')
+    router.refresh()
+  }
+
+  return (
+    <button
+      onClick={handleLogout}
+      disabled={loading}
+      className="rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-600 transition hover:bg-slate-50 disabled:opacity-60"
+    >
+      {loading ? 'Signing out…' : 'Sign out'}
+    </button>
+  )
+}

--- a/src/app/(frontend)/dashboard/page.tsx
+++ b/src/app/(frontend)/dashboard/page.tsx
@@ -1,0 +1,207 @@
+import { headers as getHeaders } from 'next/headers.js'
+import Link from 'next/link'
+import { redirect } from 'next/navigation'
+import { getPayload } from 'payload'
+import React from 'react'
+
+import config from '@/payload.config'
+import type { Dealer } from '@/payload-types'
+import { ExpensesChart, SalesChart } from '@/components/dashboard/Charts'
+import KpiCard from '@/components/dashboard/KpiCard'
+import StatusBadge from '@/components/dashboard/StatusBadge'
+import { formatCurrency, formatDate } from '@/lib/format'
+import { getDashboardData } from '@/lib/reports'
+
+import LogoutButton from './logout-button'
+
+export const dynamic = 'force-dynamic'
+
+export const metadata = {
+  title: 'Dashboard — Distribution Tracker',
+}
+
+const dealerName = (dealer: Dealer | string | null | undefined): string =>
+  dealer && typeof dealer === 'object' ? dealer.name : '—'
+
+export default async function DashboardPage() {
+  const headers = await getHeaders()
+  const payload = await getPayload({ config: await config })
+  const { user } = await payload.auth({ headers })
+
+  if (!user) redirect('/login')
+
+  const data = await getDashboardData(payload)
+
+  return (
+    <div className="min-h-screen">
+      {/* Top bar */}
+      <header className="sticky top-0 z-10 border-b border-slate-200 bg-white/80 backdrop-blur">
+        <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-3 sm:px-6">
+          <span className="text-lg font-bold tracking-tight text-slate-900">
+            Distribution<span className="text-indigo-600">Tracker</span>
+          </span>
+          <div className="flex items-center gap-3">
+            <span className="hidden text-sm text-slate-500 sm:inline">
+              {user.email}
+              <span className="ml-2 rounded-full bg-slate-100 px-2 py-0.5 text-xs capitalize text-slate-600">
+                {user.role}
+              </span>
+            </span>
+            <Link
+              href="/admin"
+              className="rounded-lg bg-slate-900 px-3 py-1.5 text-sm font-medium text-white transition hover:bg-slate-700"
+            >
+              Admin panel
+            </Link>
+            <LogoutButton />
+          </div>
+        </div>
+      </header>
+
+      <main className="mx-auto max-w-7xl px-4 py-8 sm:px-6">
+        <h1 className="mb-1 text-2xl font-bold tracking-tight text-slate-900">Dashboard</h1>
+        <p className="mb-6 text-sm text-slate-500">Overview of your distribution operations</p>
+
+        {/* KPIs */}
+        <div className="grid grid-cols-2 gap-4 lg:grid-cols-3 xl:grid-cols-6">
+          <KpiCard label="Trips today" value={String(data.kpis.tripsToday)} accent="indigo" />
+          <KpiCard
+            label="Pending deliveries"
+            value={String(data.kpis.pendingDeliveries)}
+            accent="amber"
+          />
+          <KpiCard
+            label="Outstanding"
+            value={formatCurrency(data.kpis.outstanding)}
+            accent="rose"
+            hint="Receivable from dealers"
+          />
+          <KpiCard
+            label="Sales (6 mo)"
+            value={formatCurrency(data.kpis.salesWindow)}
+            accent="emerald"
+          />
+          <KpiCard
+            label="Month expenses"
+            value={formatCurrency(data.kpis.monthExpenses)}
+            accent="slate"
+          />
+          <KpiCard
+            label="Low stock"
+            value={String(data.kpis.lowStockCount)}
+            accent={data.kpis.lowStockCount > 0 ? 'rose' : 'emerald'}
+            hint="Items at/below reorder level"
+          />
+        </div>
+
+        {/* Charts */}
+        <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-3">
+          <div className="rounded-2xl bg-white p-5 shadow-sm ring-1 ring-slate-200 lg:col-span-2">
+            <h2 className="mb-4 text-sm font-semibold text-slate-700">Sales (last 6 months)</h2>
+            <SalesChart data={data.salesByMonth} />
+          </div>
+          <div className="rounded-2xl bg-white p-5 shadow-sm ring-1 ring-slate-200">
+            <h2 className="mb-4 text-sm font-semibold text-slate-700">Expenses by type</h2>
+            <ExpensesChart data={data.expensesByType} />
+          </div>
+        </div>
+
+        {/* Lists */}
+        <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-2">
+          {/* Recent trips */}
+          <section className="rounded-2xl bg-white p-5 shadow-sm ring-1 ring-slate-200">
+            <h2 className="mb-4 text-sm font-semibold text-slate-700">Recent trips</h2>
+            <Table
+              head={['Trip', 'Date', 'Dealer', 'Status']}
+              rows={data.recentTrips.map((t) => [
+                t.tripId ?? '—',
+                formatDate(t.date),
+                dealerName(t.toLocation as Dealer | string),
+                <StatusBadge key={t.id} status={t.tripStatus} />,
+              ])}
+              empty="No trips yet."
+            />
+          </section>
+
+          {/* Recent invoices */}
+          <section className="rounded-2xl bg-white p-5 shadow-sm ring-1 ring-slate-200">
+            <h2 className="mb-4 text-sm font-semibold text-slate-700">Recent invoices</h2>
+            <Table
+              head={['Invoice', 'Dealer', 'Amount', 'Status']}
+              rows={data.recentInvoices.map((i) => [
+                i.invoiceNumber ?? '—',
+                dealerName(i.dealer as Dealer | string),
+                formatCurrency(i.totalAmount),
+                <StatusBadge key={i.id} status={i.paymentStatus} />,
+              ])}
+              empty="No invoices yet."
+            />
+          </section>
+
+          {/* Top dealer balances */}
+          <section className="rounded-2xl bg-white p-5 shadow-sm ring-1 ring-slate-200">
+            <h2 className="mb-4 text-sm font-semibold text-slate-700">Top outstanding balances</h2>
+            <Table
+              head={['Dealer', 'Balance']}
+              rows={data.topDealerBalances.map((d) => [d.dealer, formatCurrency(d.balance)])}
+              empty="All settled — no outstanding balances."
+            />
+          </section>
+
+          {/* Low stock */}
+          <section className="rounded-2xl bg-white p-5 shadow-sm ring-1 ring-slate-200">
+            <h2 className="mb-4 text-sm font-semibold text-slate-700">Low stock alerts</h2>
+            <Table
+              head={['Product', 'Available', 'Reorder at']}
+              rows={data.lowStock.map((s) => [s.product, String(s.available), String(s.reorder)])}
+              empty="Stock levels are healthy."
+            />
+          </section>
+        </div>
+      </main>
+    </div>
+  )
+}
+
+function Table({
+  head,
+  rows,
+  empty,
+}: {
+  head: string[]
+  rows: React.ReactNode[][]
+  empty: string
+}) {
+  if (!rows.length) {
+    return <p className="py-8 text-center text-sm text-slate-400">{empty}</p>
+  }
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-left text-sm">
+        <thead>
+          <tr className="border-b border-slate-200 text-xs uppercase tracking-wide text-slate-400">
+            {head.map((h) => (
+              <th key={h} className="pb-2 pr-4 font-medium last:text-right">
+                {h}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row, ri) => (
+            <tr key={ri} className="border-b border-slate-100 last:border-0">
+              {row.map((cell, ci) => (
+                <td
+                  key={ci}
+                  className="py-3 pr-4 text-slate-700 last:pr-0 last:text-right"
+                >
+                  {cell}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/src/app/(frontend)/layout.tsx
+++ b/src/app/(frontend)/layout.tsx
@@ -2,8 +2,9 @@ import React from 'react'
 import './styles.css'
 
 export const metadata = {
-  description: 'A blank template using Payload in a Next.js app.',
-  title: 'Payload Blank Template',
+  title: 'Distribution Tracker',
+  description:
+    'Manage products, dealers, deliveries, inventory, invoices and expenses — all in one place.',
 }
 
 export default async function RootLayout(props: { children: React.ReactNode }) {
@@ -11,9 +12,7 @@ export default async function RootLayout(props: { children: React.ReactNode }) {
 
   return (
     <html lang="en">
-      <body>
-        <main>{children}</main>
-      </body>
+      <body>{children}</body>
     </html>
   )
 }

--- a/src/app/(frontend)/login/login-form.tsx
+++ b/src/app/(frontend)/login/login-form.tsx
@@ -1,0 +1,75 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import React, { useState } from 'react'
+
+export default function LoginForm() {
+  const router = useRouter()
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError(null)
+    setLoading(true)
+    try {
+      const res = await fetch('/api/users/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password }),
+      })
+      if (!res.ok) {
+        const data = await res.json().catch(() => null)
+        setError(data?.errors?.[0]?.message ?? 'Invalid email or password.')
+        setLoading(false)
+        return
+      }
+      router.push('/dashboard')
+      router.refresh()
+    } catch {
+      setError('Something went wrong. Please try again.')
+      setLoading(false)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      {error && (
+        <div className="rounded-lg bg-red-50 px-4 py-3 text-sm text-red-700 ring-1 ring-red-200">
+          {error}
+        </div>
+      )}
+      <div>
+        <label className="mb-1 block text-sm font-medium text-slate-700">Email</label>
+        <input
+          type="email"
+          required
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm outline-none focus:border-indigo-500 focus:ring-2 focus:ring-indigo-100"
+          placeholder="you@company.com"
+        />
+      </div>
+      <div>
+        <label className="mb-1 block text-sm font-medium text-slate-700">Password</label>
+        <input
+          type="password"
+          required
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm outline-none focus:border-indigo-500 focus:ring-2 focus:ring-indigo-100"
+          placeholder="••••••••"
+        />
+      </div>
+      <button
+        type="submit"
+        disabled={loading}
+        className="w-full rounded-lg bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white transition hover:bg-indigo-700 disabled:opacity-60"
+      >
+        {loading ? 'Signing in…' : 'Sign in'}
+      </button>
+    </form>
+  )
+}

--- a/src/app/(frontend)/login/page.tsx
+++ b/src/app/(frontend)/login/page.tsx
@@ -1,0 +1,40 @@
+import { headers as getHeaders } from 'next/headers.js'
+import Link from 'next/link'
+import { redirect } from 'next/navigation'
+import { getPayload } from 'payload'
+import React from 'react'
+
+import config from '@/payload.config'
+
+import LoginForm from './login-form'
+
+export const metadata = {
+  title: 'Sign in — Distribution Tracker',
+}
+
+export default async function LoginPage() {
+  const headers = await getHeaders()
+  const payload = await getPayload({ config: await config })
+  const { user } = await payload.auth({ headers })
+
+  if (user) redirect('/dashboard')
+
+  return (
+    <div className="flex min-h-screen items-center justify-center px-4">
+      <div className="w-full max-w-sm">
+        <div className="mb-8 text-center">
+          <Link href="/" className="text-2xl font-bold tracking-tight text-slate-900">
+            Distribution<span className="text-indigo-600">Tracker</span>
+          </Link>
+          <p className="mt-2 text-sm text-slate-500">Sign in to your dashboard</p>
+        </div>
+        <div className="rounded-2xl bg-white p-8 shadow-sm ring-1 ring-slate-200">
+          <LoginForm />
+        </div>
+        <p className="mt-6 text-center text-xs text-slate-400">
+          Manage products, deliveries, inventory &amp; invoices
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -1,59 +1,198 @@
 import { headers as getHeaders } from 'next/headers.js'
-import Image from 'next/image'
+import Link from 'next/link'
 import { getPayload } from 'payload'
 import React from 'react'
-import { fileURLToPath } from 'url'
 
 import config from '@/payload.config'
-import './styles.css'
+
+const Icon = ({ path }: { path: string }) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.6}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className="h-5 w-5"
+    aria-hidden
+  >
+    {path.split('|').map((d, i) => (
+      <path key={i} d={d} />
+    ))}
+  </svg>
+)
+
+const features = [
+  {
+    title: 'Deliveries that update stock',
+    desc: 'Mark a trip delivered and the cartons leave your inventory on their own — no second register, no double entry.',
+    path: 'M3 7h11v8H3z|M14 10h3.5L21 13v2h-7|M6 19a1.6 1.6 0 1 0 0-3.2 1.6 1.6 0 0 0 0 3.2z|M17 19a1.6 1.6 0 1 0 0-3.2 1.6 1.6 0 0 0 0 3.2z',
+  },
+  {
+    title: 'Dealer balances you can trust',
+    desc: 'Every invoice tracks what is paid and what is still due. See each dealer’s outstanding without reaching for a calculator.',
+    path: 'M4 5h16v14H4z|M4 9h16|M8 14h5',
+  },
+  {
+    title: 'A warning before stock runs out',
+    desc: 'Set a reorder level per product. The dashboard flags whatever is getting low so you order in time, not after a stockout.',
+    path: 'M6 9a6 6 0 0 1 12 0c0 4.5 2 5.5 2 5.5H4S6 13.5 6 9z|M10 20a2 2 0 0 0 4 0',
+  },
+  {
+    title: 'The whole operation in one place',
+    desc: 'Drivers, helpers, vehicles and expenses — all linked together, with roles so each person only sees what they should.',
+    path: 'M9 10a2.6 2.6 0 1 0 0-5.2 2.6 2.6 0 0 0 0 5.2z|M3 19v-1a5 5 0 0 1 10 0v1|M16 5.2a2.6 2.6 0 0 1 0 4.8|M21 19v-1a5 5 0 0 0-4-4.4',
+  },
+]
 
 export default async function HomePage() {
   const headers = await getHeaders()
-  const payloadConfig = await config
-  const payload = await getPayload({ config: payloadConfig })
+  const payload = await getPayload({ config: await config })
   const { user } = await payload.auth({ headers })
 
-  const fileURL = `vscode://file/${fileURLToPath(import.meta.url)}`
+  const primaryHref = user ? '/dashboard' : '/login'
+  const primaryLabel = user ? 'Open the dashboard' : 'Sign in'
 
   return (
-    <div className="home">
-      <div className="content">
-        <picture>
-          <source srcSet="https://raw.githubusercontent.com/payloadcms/payload/main/packages/ui/src/assets/payload-favicon.svg" />
-          <Image
-            alt="Payload Logo"
-            height={65}
-            src="https://raw.githubusercontent.com/payloadcms/payload/main/packages/ui/src/assets/payload-favicon.svg"
-            width={65}
-          />
-        </picture>
-        {!user && <h1>Welcome to your new project.</h1>}
-        {user && <h1>Welcome back, {user.email}</h1>}
-        <div className="links">
-          <a
-            className="admin"
-            href={payloadConfig.routes.admin}
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            Go to admin panel
-          </a>
-          <a
-            className="docs"
-            href="https://payloadcms.com/docs"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            Documentation
-          </a>
+    <div className="min-h-screen bg-white">
+      {/* Nav */}
+      <header className="mx-auto flex max-w-6xl items-center justify-between px-5 py-5">
+        <span className="font-semibold tracking-tight text-slate-900">
+          Distribution<span className="text-indigo-600">Tracker</span>
+        </span>
+        <Link
+          href={primaryHref}
+          className="rounded-md bg-slate-900 px-4 py-2 text-sm font-medium text-white transition hover:bg-slate-700"
+        >
+          {user ? 'Dashboard' : 'Sign in'}
+        </Link>
+      </header>
+
+      {/* Hero */}
+      <section className="relative overflow-hidden">
+        <div
+          className="pointer-events-none absolute -top-32 right-0 h-72 w-72 rounded-full bg-indigo-100/60 blur-3xl"
+          aria-hidden
+        />
+        <div className="mx-auto grid max-w-6xl items-center gap-12 px-5 pb-16 pt-10 lg:grid-cols-2 lg:pb-24 lg:pt-16">
+          {/* Left: copy */}
+          <div>
+            <p className="text-sm font-medium text-indigo-600">For distributors &amp; wholesalers</p>
+            <h1 className="mt-3 text-4xl font-bold leading-[1.1] tracking-tight text-slate-900 sm:text-5xl">
+              Know where every delivery, rupee and carton actually is.
+            </h1>
+            <p className="mt-5 max-w-xl text-lg leading-relaxed text-slate-600">
+              Distribution Tracker keeps your trips, stock and dealer payments in step with each
+              other — so you stop reconciling numbers across registers, calculators and WhatsApp.
+            </p>
+            <div className="mt-8 flex flex-wrap items-center gap-3">
+              <Link
+                href={primaryHref}
+                className="rounded-md bg-indigo-600 px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-indigo-700"
+              >
+                {primaryLabel}
+              </Link>
+              <Link
+                href="/admin"
+                className="rounded-md px-5 py-2.5 text-sm font-semibold text-slate-700 underline-offset-4 hover:underline"
+              >
+                Open the admin panel →
+              </Link>
+            </div>
+          </div>
+
+          {/* Right: dashboard preview mock */}
+          <div className="relative">
+            <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-xl shadow-slate-200/60">
+              <div className="mb-3 flex items-center gap-1.5">
+                <span className="h-2.5 w-2.5 rounded-full bg-slate-200" />
+                <span className="h-2.5 w-2.5 rounded-full bg-slate-200" />
+                <span className="h-2.5 w-2.5 rounded-full bg-slate-200" />
+                <span className="ml-2 text-xs text-slate-400">Dashboard</span>
+              </div>
+              <div className="grid grid-cols-3 gap-2.5">
+                <PreviewStat label="Trips today" value="6" tone="text-indigo-600" />
+                <PreviewStat label="Outstanding" value="Rs 84,200" tone="text-rose-600" />
+                <PreviewStat label="Low stock" value="2" tone="text-amber-600" />
+              </div>
+              <div className="mt-3 rounded-lg border border-slate-100 p-3">
+                <p className="mb-2 text-[11px] font-medium text-slate-400">Sales — last 6 months</p>
+                <div className="flex h-24 items-end gap-2">
+                  {[38, 52, 44, 67, 58, 80].map((h, i) => (
+                    <div
+                      key={i}
+                      className="flex-1 rounded-t bg-indigo-500/80"
+                      style={{ height: `${h}%` }}
+                    />
+                  ))}
+                </div>
+              </div>
+              <div className="mt-3 space-y-2">
+                {[
+                  ['TRIP-9F2A', 'Al-Madina Store', 'Complete'],
+                  ['TRIP-7C10', 'New Karachi Mart', 'In Progress'],
+                ].map(([id, dealer, status]) => (
+                  <div
+                    key={id}
+                    className="flex items-center justify-between rounded-md bg-slate-50 px-3 py-2 text-xs"
+                  >
+                    <span className="font-medium text-slate-700">{id}</span>
+                    <span className="text-slate-400">{dealer}</span>
+                    <span
+                      className={
+                        status === 'Complete'
+                          ? 'rounded-full bg-emerald-100 px-2 py-0.5 text-emerald-700'
+                          : 'rounded-full bg-blue-100 px-2 py-0.5 text-blue-700'
+                      }
+                    >
+                      {status}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
         </div>
-      </div>
-      <div className="footer">
-        <p>Update this page by editing</p>
-        <a className="codeLink" href={fileURL}>
-          <code>app/(frontend)/page.tsx</code>
-        </a>
-      </div>
+      </section>
+
+      {/* Features */}
+      <section className="border-t border-slate-100 bg-slate-50/60">
+        <div className="mx-auto max-w-6xl px-5 py-16 lg:py-20">
+          <h2 className="max-w-2xl text-2xl font-bold tracking-tight text-slate-900">
+            Built around how a distribution business actually runs
+          </h2>
+          <div className="mt-10 grid gap-x-10 gap-y-9 sm:grid-cols-2">
+            {features.map((f) => (
+              <div key={f.title} className="flex gap-4">
+                <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-white text-indigo-600 ring-1 ring-slate-200">
+                  <Icon path={f.path} />
+                </div>
+                <div>
+                  <h3 className="text-base font-semibold text-slate-900">{f.title}</h3>
+                  <p className="mt-1.5 text-sm leading-relaxed text-slate-600">{f.desc}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Footer */}
+      <footer className="mx-auto flex max-w-6xl flex-col gap-2 px-5 py-8 text-sm text-slate-400 sm:flex-row sm:items-center sm:justify-between">
+        <span>© {new Date().getFullYear()} Distribution Tracker</span>
+        <Link href={primaryHref} className="text-slate-500 hover:text-slate-700">
+          {user ? 'Go to dashboard' : 'Sign in to your account'}
+        </Link>
+      </footer>
+    </div>
+  )
+}
+
+function PreviewStat({ label, value, tone }: { label: string; value: string; tone: string }) {
+  return (
+    <div className="rounded-lg border border-slate-100 bg-slate-50/50 p-2.5">
+      <p className="text-[10px] text-slate-400">{label}</p>
+      <p className={`mt-0.5 text-sm font-bold ${tone}`}>{value}</p>
     </div>
   )
 }

--- a/src/app/(frontend)/styles.css
+++ b/src/app/(frontend)/styles.css
@@ -1,164 +1,26 @@
+@import 'tailwindcss';
+
+/* Scan the whole src tree for class names */
+@source '../../../**/*.{ts,tsx}';
+
 :root {
-  --font-mono: 'Roboto Mono', monospace;
-}
-
-* {
-  box-sizing: border-box;
-}
-
-html {
-  font-size: 18px;
-  line-height: 32px;
-
-  background: rgb(0, 0, 0);
-  -webkit-font-smoothing: antialiased;
+  color-scheme: light;
 }
 
 html,
-body,
-#app {
-  height: 100%;
+body {
+  margin: 0;
+  padding: 0;
 }
 
 body {
-  font-family: system-ui;
-  font-size: 18px;
-  line-height: 32px;
-
-  margin: 0;
-  color: rgb(1000, 1000, 1000);
-
-  @media (max-width: 1024px) {
-    font-size: 15px;
-    line-height: 24px;
-  }
-}
-
-img {
-  max-width: 100%;
-  height: auto;
-  display: block;
-}
-
-h1 {
-  margin: 40px 0;
-  font-size: 64px;
-  line-height: 70px;
-  font-weight: bold;
-
-  @media (max-width: 1024px) {
-    margin: 24px 0;
-    font-size: 42px;
-    line-height: 42px;
-  }
-
-  @media (max-width: 768px) {
-    font-size: 38px;
-    line-height: 38px;
-  }
-
-  @media (max-width: 400px) {
-    font-size: 32px;
-    line-height: 32px;
-  }
-}
-
-p {
-  margin: 24px 0;
-
-  @media (max-width: 1024px) {
-    margin: calc(var(--base) * 0.75) 0;
-  }
-}
-
-a {
-  color: currentColor;
-
-  &:focus {
-    opacity: 0.8;
-    outline: none;
-  }
-
-  &:active {
-    opacity: 0.7;
-    outline: none;
-  }
-}
-
-svg {
-  vertical-align: middle;
-}
-
-.home {
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  align-items: center;
-  height: 100vh;
-  padding: 45px;
-  max-width: 1024px;
-  margin: 0 auto;
-  overflow: hidden;
-
-  @media (max-width: 400px) {
-    padding: 24px;
-  }
-
-  .content {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    flex-grow: 1;
-
-    h1 {
-      text-align: center;
-    }
-  }
-
-  .links {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-
-    a {
-      text-decoration: none;
-      padding: 0.25rem 0.5rem;
-      border-radius: 4px;
-    }
-
-    .admin {
-      color: rgb(0, 0, 0);
-      background: rgb(1000, 1000, 1000);
-      border: 1px solid rgb(0, 0, 0);
-    }
-
-    .docs {
-      color: rgb(1000, 1000, 1000);
-      background: rgb(0, 0, 0);
-      border: 1px solid rgb(1000, 1000, 1000);
-    }
-  }
-
-  .footer {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-
-    @media (max-width: 1024px) {
-      flex-direction: column;
-      gap: 6px;
-    }
-
-    p {
-      margin: 0;
-    }
-
-    .codeLink {
-      text-decoration: none;
-      padding: 0 0.5rem;
-      background: rgb(60, 60, 60);
-      border-radius: 4px;
-    }
-  }
+  @apply bg-slate-50 text-slate-800 antialiased;
+  font-family:
+    system-ui,
+    -apple-system,
+    'Segoe UI',
+    Roboto,
+    Helvetica,
+    Arial,
+    sans-serif;
 }

--- a/src/components/dashboard/Charts.tsx
+++ b/src/components/dashboard/Charts.tsx
@@ -1,0 +1,72 @@
+'use client'
+
+import React from 'react'
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  Pie,
+  PieChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts'
+
+const PIE_COLORS = ['#6366f1', '#10b981', '#f59e0b', '#ef4444', '#0ea5e9', '#8b5cf6', '#ec4899']
+
+const compact = (n: number) =>
+  n >= 1000 ? `${(n / 1000).toFixed(n >= 10000 ? 0 : 1)}k` : `${n}`
+
+export function SalesChart({ data }: { data: { month: string; total: number }[] }) {
+  return (
+    <ResponsiveContainer width="100%" height={240}>
+      <BarChart data={data} margin={{ top: 8, right: 8, left: 0, bottom: 0 }}>
+        <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="#e2e8f0" />
+        <XAxis dataKey="month" tick={{ fontSize: 12, fill: '#64748b' }} axisLine={false} tickLine={false} />
+        <YAxis
+          tick={{ fontSize: 12, fill: '#64748b' }}
+          axisLine={false}
+          tickLine={false}
+          tickFormatter={compact}
+        />
+        <Tooltip
+          formatter={(value) => [`Rs ${Number(value).toLocaleString()}`, 'Sales']}
+          contentStyle={{ borderRadius: 8, border: '1px solid #e2e8f0', fontSize: 12 }}
+        />
+        <Bar dataKey="total" fill="#6366f1" radius={[6, 6, 0, 0]} maxBarSize={48} />
+      </BarChart>
+    </ResponsiveContainer>
+  )
+}
+
+export function ExpensesChart({ data }: { data: { type: string; total: number }[] }) {
+  if (!data.length) {
+    return <p className="py-12 text-center text-sm text-slate-400">No expenses recorded yet.</p>
+  }
+  return (
+    <ResponsiveContainer width="100%" height={240}>
+      <PieChart>
+        <Pie
+          data={data}
+          dataKey="total"
+          nameKey="type"
+          cx="50%"
+          cy="50%"
+          innerRadius={50}
+          outerRadius={90}
+          paddingAngle={2}
+        >
+          {data.map((_, i) => (
+            <Cell key={i} fill={PIE_COLORS[i % PIE_COLORS.length]} />
+          ))}
+        </Pie>
+        <Tooltip
+          formatter={(value, name) => [`Rs ${Number(value).toLocaleString()}`, name]}
+          contentStyle={{ borderRadius: 8, border: '1px solid #e2e8f0', fontSize: 12 }}
+        />
+      </PieChart>
+    </ResponsiveContainer>
+  )
+}

--- a/src/components/dashboard/KpiCard.tsx
+++ b/src/components/dashboard/KpiCard.tsx
@@ -1,0 +1,30 @@
+import React from 'react'
+
+type KpiCardProps = {
+  label: string
+  value: string
+  hint?: string
+  accent?: 'indigo' | 'emerald' | 'amber' | 'rose' | 'slate'
+}
+
+const accents: Record<NonNullable<KpiCardProps['accent']>, string> = {
+  indigo: 'bg-indigo-50 text-indigo-700',
+  emerald: 'bg-emerald-50 text-emerald-700',
+  amber: 'bg-amber-50 text-amber-700',
+  rose: 'bg-rose-50 text-rose-700',
+  slate: 'bg-slate-100 text-slate-700',
+}
+
+export default function KpiCard({ label, value, hint, accent = 'slate' }: KpiCardProps) {
+  return (
+    <div className="rounded-2xl bg-white p-5 shadow-sm ring-1 ring-slate-200">
+      <span
+        className={`inline-block rounded-full px-2.5 py-0.5 text-xs font-medium ${accents[accent]}`}
+      >
+        {label}
+      </span>
+      <p className="mt-3 text-2xl font-bold tracking-tight text-slate-900">{value}</p>
+      {hint && <p className="mt-1 text-xs text-slate-400">{hint}</p>}
+    </div>
+  )
+}

--- a/src/components/dashboard/StatusBadge.tsx
+++ b/src/components/dashboard/StatusBadge.tsx
@@ -1,0 +1,33 @@
+import React from 'react'
+
+const styles: Record<string, string> = {
+  // trip statuses
+  pending: 'bg-amber-50 text-amber-700 ring-amber-200',
+  in_progress: 'bg-blue-50 text-blue-700 ring-blue-200',
+  complete: 'bg-emerald-50 text-emerald-700 ring-emerald-200',
+  // payment statuses
+  unpaid: 'bg-rose-50 text-rose-700 ring-rose-200',
+  partial: 'bg-amber-50 text-amber-700 ring-amber-200',
+  paid: 'bg-emerald-50 text-emerald-700 ring-emerald-200',
+}
+
+const labels: Record<string, string> = {
+  pending: 'Pending',
+  in_progress: 'In Progress',
+  complete: 'Complete',
+  unpaid: 'Unpaid',
+  partial: 'Partial',
+  paid: 'Paid',
+}
+
+export default function StatusBadge({ status }: { status?: string | null }) {
+  const key = status ?? 'pending'
+  const style = styles[key] ?? 'bg-slate-100 text-slate-600 ring-slate-200'
+  return (
+    <span
+      className={`inline-block rounded-full px-2.5 py-0.5 text-xs font-medium ring-1 ${style}`}
+    >
+      {labels[key] ?? key}
+    </span>
+  )
+}

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,0 +1,13 @@
+/** Format a number as Pakistani Rupees, e.g. 12500 -> "Rs 12,500". */
+export function formatCurrency(value: number | null | undefined): string {
+  const n = Number(value) || 0
+  return `Rs ${n.toLocaleString('en-PK', { maximumFractionDigits: 0 })}`
+}
+
+/** Format an ISO date string as a short readable date, e.g. "08 Jun 2026". */
+export function formatDate(value: string | null | undefined): string {
+  if (!value) return '—'
+  const d = new Date(value)
+  if (Number.isNaN(d.getTime())) return '—'
+  return d.toLocaleDateString('en-GB', { day: '2-digit', month: 'short', year: 'numeric' })
+}

--- a/src/lib/reports.ts
+++ b/src/lib/reports.ts
@@ -1,0 +1,178 @@
+import type { Payload } from 'payload'
+
+import type { Dealer, Invoice, Trip } from '@/payload-types'
+
+export type DashboardData = {
+  kpis: {
+    tripsToday: number
+    pendingDeliveries: number
+    outstanding: number
+    lowStockCount: number
+    monthExpenses: number
+    salesWindow: number
+  }
+  recentTrips: Trip[]
+  recentInvoices: Invoice[]
+  topDealerBalances: { dealer: string; balance: number }[]
+  lowStock: { product: string; available: number; reorder: number }[]
+  salesByMonth: { month: string; total: number }[]
+  expensesByType: { type: string; total: number }[]
+}
+
+const titleOf = (rel: unknown, key: string): string => {
+  if (rel && typeof rel === 'object') {
+    return String((rel as Record<string, unknown>)[key] ?? '—')
+  }
+  return '—'
+}
+
+/**
+ * Build the dashboard payload. Counts run as DB-side `count` queries, sums and
+ * charts are scoped with `where` filters + a rolling 6-month window and trimmed
+ * with `select`, so we never load entire collections into memory.
+ */
+export async function getDashboardData(payload: Payload): Promise<DashboardData> {
+  const now = new Date()
+  const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate())
+  const endOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 23, 59, 59, 999)
+  const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1)
+  const sixMonthsAgo = new Date(now.getFullYear(), now.getMonth() - 5, 1)
+
+  const [
+    tripsTodayRes,
+    pendingRes,
+    recentTripsRes,
+    recentInvoicesRes,
+    openInvoicesRes,
+    windowInvoicesRes,
+    monthExpensesRes,
+    windowExpensesRes,
+    inventoryRes,
+  ] = await Promise.all([
+    payload.count({
+      collection: 'trips',
+      where: {
+        date: {
+          greater_than_equal: startOfToday.toISOString(),
+          less_than_equal: endOfToday.toISOString(),
+        },
+      },
+    }),
+    payload.count({
+      collection: 'trips',
+      where: { tripStatus: { in: ['pending', 'in_progress'] } },
+    }),
+    payload.find({ collection: 'trips', limit: 6, sort: '-date', depth: 1 }),
+    payload.find({ collection: 'invoices', limit: 6, sort: '-invoiceDate', depth: 1 }),
+    // open invoices only (drives outstanding + dealer balances)
+    payload.find({
+      collection: 'invoices',
+      where: { balanceDue: { greater_than: 0 } },
+      depth: 1,
+      pagination: false,
+      select: { balanceDue: true, dealer: true },
+    }),
+    // last 6 months of invoices (drives sales KPI + chart)
+    payload.find({
+      collection: 'invoices',
+      where: { invoiceDate: { greater_than_equal: sixMonthsAgo.toISOString() } },
+      depth: 0,
+      pagination: false,
+      select: { totalAmount: true, invoiceDate: true },
+    }),
+    // this month's expenses (sum only)
+    payload.find({
+      collection: 'expenses',
+      where: { date: { greater_than_equal: startOfMonth.toISOString() } },
+      depth: 0,
+      pagination: false,
+      select: { amount: true },
+    }),
+    // last 6 months of expenses (by-type chart)
+    payload.find({
+      collection: 'expenses',
+      where: { date: { greater_than_equal: sixMonthsAgo.toISOString() } },
+      depth: 0,
+      pagination: false,
+      select: { amount: true, expenseType: true },
+    }),
+    // inventory is bounded (one row per product)
+    payload.find({
+      collection: 'inventory',
+      depth: 1,
+      pagination: false,
+      select: { product: true, availableQuantity: true, reorderLevel: true },
+    }),
+  ])
+
+  const outstanding = openInvoicesRes.docs.reduce((s, i) => s + (i.balanceDue ?? 0), 0)
+  const salesWindow = windowInvoicesRes.docs.reduce((s, i) => s + (i.totalAmount ?? 0), 0)
+  const monthExpenses = monthExpensesRes.docs.reduce((s, e) => s + (e.amount ?? 0), 0)
+
+  const lowStockItems = inventoryRes.docs.filter(
+    (i) => (i.availableQuantity ?? 0) <= (i.reorderLevel ?? 0),
+  )
+
+  // Top dealer balances (from open invoices only)
+  const dealerMap = new Map<string, number>()
+  for (const inv of openInvoicesRes.docs) {
+    const name = titleOf(inv.dealer as Dealer | string, 'name')
+    dealerMap.set(name, (dealerMap.get(name) ?? 0) + (inv.balanceDue ?? 0))
+  }
+  const topDealerBalances = [...dealerMap.entries()]
+    .map(([dealer, balance]) => ({ dealer, balance }))
+    .filter((d) => d.balance > 0)
+    .sort((a, b) => b.balance - a.balance)
+    .slice(0, 5)
+
+  // Sales by month (rolling 6 months)
+  const monthKeys: { key: string; label: string }[] = []
+  for (let i = 5; i >= 0; i--) {
+    const d = new Date(now.getFullYear(), now.getMonth() - i, 1)
+    monthKeys.push({
+      key: `${d.getFullYear()}-${d.getMonth()}`,
+      label: d.toLocaleDateString('en-GB', { month: 'short' }),
+    })
+  }
+  const salesByMonth = monthKeys.map(({ key, label }) => {
+    const total = windowInvoicesRes.docs
+      .filter((inv) => {
+        if (!inv.invoiceDate) return false
+        const d = new Date(inv.invoiceDate)
+        return `${d.getFullYear()}-${d.getMonth()}` === key
+      })
+      .reduce((sum, inv) => sum + (inv.totalAmount ?? 0), 0)
+    return { month: label, total }
+  })
+
+  // Expenses by type (rolling 6 months)
+  const typeMap = new Map<string, number>()
+  for (const e of windowExpensesRes.docs) {
+    const type = e.expenseType ?? 'Other'
+    typeMap.set(type, (typeMap.get(type) ?? 0) + (e.amount ?? 0))
+  }
+  const expensesByType = [...typeMap.entries()]
+    .map(([type, total]) => ({ type, total }))
+    .sort((a, b) => b.total - a.total)
+
+  return {
+    kpis: {
+      tripsToday: tripsTodayRes.totalDocs,
+      pendingDeliveries: pendingRes.totalDocs,
+      outstanding,
+      lowStockCount: lowStockItems.length,
+      monthExpenses,
+      salesWindow,
+    },
+    recentTrips: recentTripsRes.docs,
+    recentInvoices: recentInvoicesRes.docs,
+    topDealerBalances,
+    lowStock: lowStockItems.slice(0, 6).map((i) => ({
+      product: titleOf(i.product, 'productName'),
+      available: i.availableQuantity ?? 0,
+      reorder: i.reorderLevel ?? 0,
+    })),
+    salesByMonth,
+    expensesByType,
+  }
+}


### PR DESCRIPTION
Customer-facing frontend on top of the Payload admin.

  - Public landing page (Tailwind), replacing the default template
  - Login page + protected `/dashboard` (redirects to login when unauthenticated)
  - Dashboard KPIs, sales/expense charts (Recharts), recent trips & invoices, top outstanding balances, low-stock alerts
  - Reusable UI components (KpiCard, StatusBadge, Charts)
  - `src/lib/reports.ts` uses DB-side counts, `where` filters and a rolling 6-month window — never loads whole collections